### PR TITLE
Update Skript to 2.15.3

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        skript-version: [2.15.0, 2.14.3, 2.13.2, 2.12.2, 2.11.2, 2.10.2]
+        skript-version: [2.15.3, 2.14.3, 2.13.2, 2.12.2, 2.11.2, 2.10.2]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -38,7 +38,7 @@ jobs:
           path: build/libs
           
       - name: Run tests with Skript ${{ matrix.skript-version }} (legacy)
-        if: matrix.skript-version != '2.15.0'
+        if: matrix.skript-version != '2.15.3'
         uses: SkriptLang/skript-test-action@v1.2
         with:
           test_script_directory: src/test/resources
@@ -47,7 +47,7 @@ jobs:
           run_vanilla_tests: false
 
       - name: Run tests with Skript ${{ matrix.skript-version }} (modern)
-        if: matrix.skript-version == '2.15.0'
+        if: matrix.skript-version == '2.15.3'
         uses: SkriptLang/skript-test-action@v1.3
         with:
           test_script_directory: src/test/resources

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 dependencies {
     implementation group: 'org.mongodb', name: 'mongodb-driver-reactivestreams', version: '5.7.0'
     compileOnly group: 'io.papermc.paper', name: 'paper-api', version: '1.21.11-R0.1-SNAPSHOT'
-    compileOnly group: 'com.github.SkriptLang', name: 'Skript', version: '2.15.2', {
+    compileOnly group: 'com.github.SkriptLang', name: 'Skript', version: '2.15.3', {
         exclude module: 'Vault'
         exclude module: 'worldguard'
         exclude module: 'worldguard-legacy'
@@ -24,7 +24,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:6.0.3'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.0.3'
     testImplementation group: 'io.papermc.paper', name: 'paper-api', version: '1.21.11-R0.1-SNAPSHOT'
-    testImplementation group: 'com.github.SkriptLang', name: 'Skript', version: '2.15.2', {
+    testImplementation group: 'com.github.SkriptLang', name: 'Skript', version: '2.15.3', {
         exclude module: 'Vault'
         exclude module: 'worldguard'
         exclude module: 'worldguard-legacy'

--- a/src/main/java/fr/romitou/mongosk/skript/events/MongoCommandFailed.java
+++ b/src/main/java/fr/romitou/mongosk/skript/events/MongoCommandFailed.java
@@ -3,13 +3,10 @@ package fr.romitou.mongosk.skript.events;
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.util.SimpleEvent;
 import ch.njol.skript.registrations.EventValues;
-import ch.njol.skript.util.Getter;
 import fr.romitou.mongosk.elements.MongoSKServer;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
-
-import javax.annotation.Nonnull;
 
 public class MongoCommandFailed extends Event {
 
@@ -23,29 +20,9 @@ public class MongoCommandFailed extends Event {
             "mongo[(db|sk)] command fail[ed]"
         );
 
-        EventValues.registerEventValue(MongoCommandFailed.class, MongoSKServer.class, new Getter<MongoSKServer, MongoCommandFailed>() {
-            @Nonnull
-            @Override
-            public MongoSKServer get(@Nonnull MongoCommandFailed event) {
-                return event.getMongoSKServer();
-            }
-        }, 0);
-
-        EventValues.registerEventValue(MongoCommandFailed.class, String.class, new Getter<String, MongoCommandFailed>() {
-            @Nonnull
-            @Override
-            public String get(@Nonnull MongoCommandFailed event) {
-                return event.getThrowable().getMessage();
-            }
-        }, 0);
-
-        EventValues.registerEventValue(MongoCommandFailed.class, Long.class, new Getter<Long, MongoCommandFailed>() {
-            @Nonnull
-            @Override
-            public Long get(@Nonnull MongoCommandFailed event) {
-                return event.getElapsedTime();
-            }
-        }, 0);
+        EventValues.registerEventValue(MongoCommandFailed.class, MongoSKServer.class, MongoCommandFailed::getMongoSKServer, 0);
+        EventValues.registerEventValue(MongoCommandFailed.class, String.class, event -> event.getThrowable().getMessage(), 0);
+        EventValues.registerEventValue(MongoCommandFailed.class, Long.class, MongoCommandFailed::getElapsedTime, 0);
     }
 
     private final MongoSKServer mongoSKServer;

--- a/src/main/java/fr/romitou/mongosk/skript/events/MongoCommandStarted.java
+++ b/src/main/java/fr/romitou/mongosk/skript/events/MongoCommandStarted.java
@@ -3,7 +3,6 @@ package fr.romitou.mongosk.skript.events;
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.util.SimpleEvent;
 import ch.njol.skript.registrations.EventValues;
-import ch.njol.skript.util.Getter;
 import fr.romitou.mongosk.adapters.MongoSKAdapter;
 import fr.romitou.mongosk.elements.MongoSKDocument;
 import fr.romitou.mongosk.elements.MongoSKServer;
@@ -11,8 +10,6 @@ import org.bson.BsonDocument;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
-
-import javax.annotation.Nonnull;
 
 public class MongoCommandStarted extends Event {
 
@@ -26,29 +23,9 @@ public class MongoCommandStarted extends Event {
             "mongo[(db|sk)] command start[ed]"
         );
 
-        EventValues.registerEventValue(MongoCommandStarted.class, MongoSKServer.class, new Getter<MongoSKServer, MongoCommandStarted>() {
-            @Nonnull
-            @Override
-            public MongoSKServer get(@Nonnull MongoCommandStarted event) {
-                return event.getMongoSKServer();
-            }
-        }, 0);
-
-        EventValues.registerEventValue(MongoCommandStarted.class, MongoSKDocument.class, new Getter<MongoSKDocument, MongoCommandStarted>() {
-            @Nonnull
-            @Override
-            public MongoSKDocument get(@Nonnull MongoCommandStarted event) {
-                return event.getCommand();
-            }
-        }, 0);
-
-        EventValues.registerEventValue(MongoCommandStarted.class, String.class, new Getter<String, MongoCommandStarted>() {
-            @Nonnull
-            @Override
-            public String get(@Nonnull MongoCommandStarted event) {
-                return event.getDatabaseName();
-            }
-        }, 0);
+        EventValues.registerEventValue(MongoCommandStarted.class, MongoSKServer.class, MongoCommandStarted::getMongoSKServer, 0);
+        EventValues.registerEventValue(MongoCommandStarted.class, MongoSKDocument.class, MongoCommandStarted::getCommand, 0);
+        EventValues.registerEventValue(MongoCommandStarted.class, String.class, MongoCommandStarted::getDatabaseName, 0);
     }
 
     private final MongoSKServer mongoSKServer;

--- a/src/main/java/fr/romitou/mongosk/skript/events/MongoCommandSucceeded.java
+++ b/src/main/java/fr/romitou/mongosk/skript/events/MongoCommandSucceeded.java
@@ -3,7 +3,6 @@ package fr.romitou.mongosk.skript.events;
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.util.SimpleEvent;
 import ch.njol.skript.registrations.EventValues;
-import ch.njol.skript.util.Getter;
 import fr.romitou.mongosk.adapters.MongoSKAdapter;
 import fr.romitou.mongosk.elements.MongoSKDocument;
 import fr.romitou.mongosk.elements.MongoSKServer;
@@ -11,8 +10,6 @@ import org.bson.BsonDocument;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
-
-import javax.annotation.Nonnull;
 
 public class MongoCommandSucceeded extends Event {
 
@@ -26,29 +23,9 @@ public class MongoCommandSucceeded extends Event {
             "mongo[(db|sk)] command (success|succeeded)"
         );
 
-        EventValues.registerEventValue(MongoCommandSucceeded.class, MongoSKServer.class, new Getter<MongoSKServer, MongoCommandSucceeded>() {
-            @Nonnull
-            @Override
-            public MongoSKServer get(@Nonnull MongoCommandSucceeded event) {
-                return event.getMongoSKServer();
-            }
-        }, 0);
-
-        EventValues.registerEventValue(MongoCommandSucceeded.class, MongoSKDocument.class, new Getter<MongoSKDocument, MongoCommandSucceeded>() {
-            @Nonnull
-            @Override
-            public MongoSKDocument get(@Nonnull MongoCommandSucceeded event) {
-                return event.getCommand();
-            }
-        }, 0);
-
-        EventValues.registerEventValue(MongoCommandSucceeded.class, Long.class, new Getter<Long, MongoCommandSucceeded>() {
-            @Nonnull
-            @Override
-            public Long get(@Nonnull MongoCommandSucceeded event) {
-                return event.getElapsedTime();
-            }
-        }, 0);
+        EventValues.registerEventValue(MongoCommandSucceeded.class, MongoSKServer.class, MongoCommandSucceeded::getMongoSKServer, 0);
+        EventValues.registerEventValue(MongoCommandSucceeded.class, MongoSKDocument.class, MongoCommandSucceeded::getCommand, 0);
+        EventValues.registerEventValue(MongoCommandSucceeded.class, Long.class, MongoCommandSucceeded::getElapsedTime, 0);
     }
 
     private final MongoSKServer mongoSKServer;


### PR DESCRIPTION
Closes #168

This updates MongoSK for Skript 2.15.3 compatibility.

Changes:
- Bumps the Gradle Skript dependency from `2.15.2` to `2.15.3`
- Updates the CI Skript 2.15 test lane to `2.15.3`
- Updates Mongo command event value registration to use Skript's `Converter`-based `EventValues.registerEventValue(...)` API

This fixes the runtime failure:

```text
NoSuchMethodError: EventValues.registerEventValue(..., Getter, int)
```

Tested:
- Built the patched plugin jar locally
- Installed the generated MongoSK-2.4.1-all.jar into a Purpur 1.21.11 test server
- Tested with: Skript 2.15.3
- MongoSK 2.4.1
- SkBee 3.25.0

Server test result:
```text
[Skript] Loading server plugin Skript v2.15.3
[MongoSK] Loading server plugin MongoSK v2.4.1
[MongoSK] Enabling MongoSK v2.4.1*
Registration of the MongoSK syntaxes...
MongoSK has been activated and the syntaxes has been loaded successfully in 78ms!
[Skript] All scripts loaded without errors.
```

The previous `EventValues.registerEventValue(..., Getter, int)` error did not occur.

Note: one separate non-fatal codec warning remains during startup:
```text
Oops, the return class of the fr.romitou.mongosk.adapters.codecs.DamageCauseCodec codec doesn't exists! Skipping registration.
```

MongoSK still enabled successfully after this warning.